### PR TITLE
Fix: vanilla sh cannot run local/download_and_untar.sh

### DIFF
--- a/egs/aishell/run.sh
+++ b/egs/aishell/run.sh
@@ -23,10 +23,10 @@ if [ ${stage} -le -1 ]; then
     ### But you can utilize Kaldi recipes in most cases
     echo "stage 0: Data preparation"
 
-    sh local/download_and_untar.sh $data $data_url data_aishell || exit 1;
-    sh local/download_and_untar.sh $data $data_url resource_aishell || exit 1;
+    bash local/download_and_untar.sh $data $data_url data_aishell || exit 1;
+    bash local/download_and_untar.sh $data $data_url resource_aishell || exit 1;
 
-    sh local/aishell_data_prep.sh $data/data_aishell/wav $data/data_aishell/transcript || exit 1;
+    bash local/aishell_data_prep.sh $data/data_aishell/wav $data/data_aishell/transcript || exit 1;
 
     for name in train test dev;do
         python local/split_and_norm.py data/$name/text.org data/$name/text || exit 1;


### PR DESCRIPTION
The script `local/download_and_untar.sh` depends on `bash` feature of `[` testing. So don't use `sh` to run it. If the `sh` command is vanilla `sh` in the user's machine, it would occur an error as follows.

```
local/download_and_untar.sh: 33: [: data_aishell: unexpected operator
local/download_and_untar.sh: 33: [: data_aishell: unexpected operator
local/download_and_untar.sh: expected <corpus-part> to be one of data_aishell resource_aishell, but got 'data_aishell'
```
